### PR TITLE
AMFデータの先頭バイトが0だった場合decode_command/2と同様の対応をdecode_data/2にも追加

### DIFF
--- a/src/rtmpmsg_message_decode.erl
+++ b/src/rtmpmsg_message_decode.erl
@@ -137,7 +137,12 @@ decode_command(AmfVersion0, Payload0) ->
     }.
 
 -spec decode_data(amf:amf_version(), binary()) -> rtmpmsg:message_body_data().
-decode_data(AmfVersion, Payload) ->
+decode_data(AmfVersion0, Payload0) ->
+    {AmfVersion, Payload} =
+        case {AmfVersion0, Payload0} of
+            {amf3, <<0, Rest/binary>>} -> {amf0, Rest};  % NOTE: 理由は分からないがFlashPlayerはこのような変則的なデータを送ってくる
+            _                          -> {AmfVersion0, Payload0}
+        end,
     #rtmpmsg_data{amf_version = AmfVersion,
                   values      = decode_amf_values(AmfVersion, Payload, [])}.
 


### PR DESCRIPTION
FlashのNetStream.send()関数で送信したメッセージのデコードに失敗する場合があったので修正しました．

decode_command/2 にすでに同様の対応があったので decode_data/2 にもそのまま入れました．
