### PR TITLE
Raise an error when message length is invalid

### DIFF
--- a/src/rtmpmsg_chunk_decode.erl
+++ b/src/rtmpmsg_chunk_decode.erl
@@ -158,6 +158,8 @@ decode_message(Bin, Fmt, LastChunk, ChunkSize) ->
 decode_message_payload(Bin, LastChunk, MaxPayloadSize) ->
     #last_chunk{msg_length=MsgLen, acc_payload=AccPayload, acc_payload_len=AccLen} = LastChunk,
     ChunkPayloadSize = min(MsgLen - AccLen, MaxPayloadSize),
+    if ChunkPayloadSize =< 0 -> error({msg_length_must_be_larger_than_acc_payload_len, MsgLen, AccLen});
+       true -> ok end,
     case Bin of
         <<Payload:ChunkPayloadSize/binary, Bin1/binary>> ->
             AccPayload1 = [Payload|AccPayload],

--- a/src/rtmpmsg_chunk_decode.erl
+++ b/src/rtmpmsg_chunk_decode.erl
@@ -158,8 +158,7 @@ decode_message(Bin, Fmt, LastChunk, ChunkSize) ->
 decode_message_payload(Bin, LastChunk, MaxPayloadSize) ->
     #last_chunk{msg_length=MsgLen, acc_payload=AccPayload, acc_payload_len=AccLen} = LastChunk,
     ChunkPayloadSize = min(MsgLen - AccLen, MaxPayloadSize),
-    if ChunkPayloadSize =< 0 -> error({msg_length_must_be_larger_than_acc_payload_len, MsgLen, AccLen});
-       true -> ok end,
+    ChunkPayloadSize < 0 andalso error({msg_length_must_be_larger_than_acc_payload_len, MsgLen, AccLen}),
     case Bin of
         <<Payload:ChunkPayloadSize/binary, Bin1/binary>> ->
             AccPayload1 = [Payload|AccPayload],

--- a/test/rtmpmsg_chunk_decode_tests.erl
+++ b/test/rtmpmsg_chunk_decode_tests.erl
@@ -316,6 +316,25 @@ reset_test_() ->
       end}
     ].
 
+invalid_chunk_test_() ->
+    [
+     {"不正なサイズ情報を持っているチャンクに対してエラーが発生する",
+      fun () ->
+              %% 初期化 チャンクサイズは 8
+              DecInit = rtmpmsg_chunk_decode:set_chunk_size(rtmpmsg_chunk_decode:init(), 8),
+              {_, InitInputBin} = encode_chunks([input_chunk()]),
+              {_, Dec0, _} = rtmpmsg_chunk_decode:decode(DecInit, InitInputBin),
+
+              %% チャンクサイズが 8 なので 9 の長さを持ったメッセージは2つに分割されているが後者の MsgLen が不正
+              %% Fmt: 1, ChunkId: 4, TimeDelta: 34, MsgLen: 9, MsgTypeId: 3, Rest: <<0, 0, 0, 0, 0, 0, 0, 0>>
+              ChunkBin = <<68, 0, 0, 34, 0, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0>>,
+              %% Fmt: 1, ChunkId: 4, TimeDelta: 34, MsgLen: 1, MsgTypeId: 3, Rest: <<0>>
+              InvalidLengthChunkBin = <<68, 0, 0, 34, 0, 0, 1, 3, 0>>,
+
+              ?assertError(_, rtmpmsg_chunk_decode:decode(Dec0, <<ChunkBin/binary, InvalidLengthChunkBin/binary>>))
+      end}
+    ].
+
 input_chunk() ->
     #chunk{id            = 4,
            msg_stream_id = 2,

--- a/test/rtmpmsg_chunk_decode_tests.erl
+++ b/test/rtmpmsg_chunk_decode_tests.erl
@@ -325,9 +325,14 @@ invalid_chunk_test_() ->
               {_, InitInputBin} = encode_chunks([input_chunk()]),
               {_, Dec0, _} = rtmpmsg_chunk_decode:decode(DecInit, InitInputBin),
 
+              %% msg_length = 0 の場合は許容する
+              %% Fmt: 1, ChunkId: 4, TimeDelta: 34, MsgLen: 0, MsgTypeId: 3, Rest: <<0, 0, 0, 0, 0, 0, 0, 0>>
+              MsgLength0ChunkBin = <<68, 0, 0, 34, 0, 0, 0, 3>>,
+              ?assertMatch({#chunk{}, _, _}, rtmpmsg_chunk_decode:decode(Dec0, MsgLength0ChunkBin)),
+
               %% チャンクサイズが 8 なので 9 の長さを持ったメッセージは2つに分割されているが後者の MsgLen が不正
               %% Fmt: 1, ChunkId: 4, TimeDelta: 34, MsgLen: 9, MsgTypeId: 3, Rest: <<0, 0, 0, 0, 0, 0, 0, 0>>
-              ChunkBin = <<68, 0, 0, 34, 0, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0>>,
+              ChunkBin = <<68, 0, 0, 34, 0, 0, 9, 3, 0, 0, 0, 0, 0, 0, 0, 0>>,
               %% Fmt: 1, ChunkId: 4, TimeDelta: 34, MsgLen: 1, MsgTypeId: 3, Rest: <<0>>
               InvalidLengthChunkBin = <<68, 0, 0, 34, 0, 0, 1, 3, 0>>,
 


### PR DESCRIPTION
不正な RTMP メッセージにより「すでに受信したチャンクの長さより短いメッセージの長」という状態に陥った時に、「未消化バイナリから先頭 -N バイトを消化する」みたいなマッチをしようとして失敗し、無限に未消化バイナリが増えていっていた。

代理PRです.